### PR TITLE
chore: pin the versions

### DIFF
--- a/akamai/1.0.0/requirements.txt
+++ b/akamai/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/archiveorg/1.0.0/requirements.txt
+++ b/archiveorg/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-requests
-savepagenow 
+requests==2.25.1
+savepagenow==1.1.1

--- a/archivetoday/1.0.0/requirements.txt
+++ b/archivetoday/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-requests
-archiveis
+requests==2.25.1
+archiveis==0.0.9

--- a/atp/1.0.0/requirements.txt
+++ b/atp/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/aws-ec2/1.0.0/requirements.txt
+++ b/aws-ec2/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-boto3
-requests
+boto3==1.16.59
+requests==2.25.1

--- a/aws-s3/1.0.0/requirements.txt
+++ b/aws-s3/1.0.0/requirements.txt
@@ -1,3 +1,3 @@
-boto3
-bson
-requests
+boto3==1.16.59
+bson==0.5.10
+requests==2.25.1

--- a/aws-securityhub/1.0.0/requirements.txt
+++ b/aws-securityhub/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-boto3
-requests
+boto3==1.16.59
+requests==2.25.1

--- a/aws-waf/1.0.0/requirements.txt
+++ b/aws-waf/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-boto3
-requests
+boto3==1.16.59
+requests==2.25.1

--- a/cortex/1.0.0/requirements.txt
+++ b/cortex/1.0.0/requirements.txt
@@ -1,3 +1,3 @@
-requests
-python-magic
-cortex4py
+requests==2.25.1
+python-magic==0.4.18
+cortex4py==2.0.1

--- a/email/1.0.0/requirements.txt
+++ b/email/1.0.0/requirements.txt
@@ -1,3 +1,3 @@
-requests
-eml_parser
-glom
+requests==2.25.1
+eml_parser==1.14.4
+glom==20.11.0

--- a/gpg/1.0.0/requirements.txt
+++ b/gpg/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-python-gnupg
-requests
+python-gnupg==0.4.6
+requests==2.25.1

--- a/hoxhunt/1.0.0/requirements.txt
+++ b/hoxhunt/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/http/1.0.0/requirements.txt
+++ b/http/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-requests
-uncurl
+uncurl==0.0.10
+requests==2.25.1

--- a/lastline/1.0.0/requirements.txt
+++ b/lastline/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/misp/1.0.0/requirements.txt
+++ b/misp/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/netcraft/1.0.0/requirements.txt
+++ b/netcraft/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/nlp/1.0.0/requirements.txt
+++ b/nlp/1.0.0/requirements.txt
@@ -1,4 +1,4 @@
-cyberspacy
-spacy
-tika
-requests
+cyberspacy==1.1.1
+spacy==2.3.5
+tika==1.24
+requests==2.25.1

--- a/owa/1.0.0/requirements.txt
+++ b/owa/1.0.0/requirements.txt
@@ -1,4 +1,4 @@
-requests
-exchangelib
-eml_parser
-glom
+exchangelib==3.3.2
+eml_parser==1.14.4
+glom==20.11.0
+requests==2.25.1

--- a/passivetotal/1.0.0/requirements.txt
+++ b/passivetotal/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/python-playground/1.0.0/requirements.txt
+++ b/python-playground/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/recordedfuture/1.0.0/requirements.txt
+++ b/recordedfuture/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/secureworks/1.0.0/requirements.txt
+++ b/secureworks/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/servicenow/1.0.0/requirements.txt
+++ b/servicenow/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/shuffle-subflow/1.0.0/requirements.txt
+++ b/shuffle-subflow/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/shuffle-tools/1.0.0/requirements.txt
+++ b/shuffle-tools/1.0.0/requirements.txt
@@ -1,5 +1,5 @@
-ioc_finder
-requests
-py7zr
-rarfile
-pyminizip
+ioc_finder==5.0.1
+py7zr==0.11.3
+rarfile==4.0
+pyminizip==0.2.4
+requests==2.25.1

--- a/siemonster/1.0.0/requirements.txt
+++ b/siemonster/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/splunk/1.0.0/requirements.txt
+++ b/splunk/1.0.0/requirements.txt
@@ -1,2 +1,2 @@
-requests
-python-magic
+python-magic==0.4.18
+requests==2.25.1

--- a/testing/1.0.0/requirements.txt
+++ b/testing/1.0.0/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.25.1

--- a/thehive/1.0.0/requirements.txt
+++ b/thehive/1.0.0/requirements.txt
@@ -1,3 +1,3 @@
-requests
-thehive4py
-python-magic
+requests==2.25.1
+thehive4py==1.8.1
+python-magic==0.4.18

--- a/yara/1.0.0/requirements.txt
+++ b/yara/1.0.0/requirements.txt
@@ -1,3 +1,2 @@
 # No extra requirements needed
-requests
-yara
+requests==2.25.1


### PR DESCRIPTION
Pin the versions to prevent unintentional breaking changes in APIs in the dependencies