### PR TITLE
Add JQ

### DIFF
--- a/shuffle-tools/1.0.0/Dockerfile
+++ b/shuffle-tools/1.0.0/Dockerfile
@@ -20,6 +20,7 @@ COPY src /app
 
 # Install any binary dependencies needed in our final image
 # RUN apk --no-cache add --update my_binary_dependency
+RUN apk --no-cache add jq
 
 # Finally, lets run our app!
 WORKDIR /app


### PR DESCRIPTION
Adding JQ as a dependency in the `shuffle-tools` Dockerfile.

This will provide more flexibility when handling JSON data via `execute bash` actions.

![image](https://user-images.githubusercontent.com/11653079/113314741-9d07ec00-92da-11eb-86ec-cbaad2d73968.png)
![image](https://user-images.githubusercontent.com/11653079/113314777-a6915400-92da-11eb-9c14-99cea10e8635.png)
