### PR TITLE
Add categories to OWA output_dict

### DIFF
--- a/owa/1.0.0/src/app.py
+++ b/owa/1.0.0/src/app.py
@@ -418,6 +418,9 @@ class Owa(AppBase):
 
                 # Add message_id as top returned field
                 output_dict["message_id"] = parsed_eml["header"]["header"]["message-id"][0]
+                
+                # Add categories to output dict
+                output_dict["categories"] = email.categories
 
                 if upload_email_shuffle:
                     email_up = [{"filename": "email.msg",


### PR DESCRIPTION
Realized that it would be helpful to see which categories/tags an email item currently has.

![image](https://user-images.githubusercontent.com/11653079/114416644-e11eaa80-9b7e-11eb-9b12-3c419795f587.png)
