### PR TITLE
Optimize Snort image size

### DIFF
--- a/snort3/1.0.0/Dockerfile
+++ b/snort3/1.0.0/Dockerfile
@@ -5,48 +5,74 @@ FROM base
 
 # Install all alpine build tools needed for our pip installs
 RUN echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
-  apk add --no-cache --update libffi libffi-dev musl-dev alpine-sdk libunwind-dev linux-headers libpcap-dev cmake libdnet-dev \
-    hwloc-dev luajit-dev openssl-dev pcre-dev libtirpc-dev flatbuffers-dev hyperscan-dev flex flex-dev
+  apk add --no-cache --update \ 
+    libffi \
+    abuild \
+    build-base \
+    cmake \
+    flex \
+    linux-headers \
+    # Library
+    libffi-dev \
+    musl-dev \
+    libunwind-dev \
+    libpcap-dev \
+    libdnet-dev \
+    hwloc-dev \
+    luajit-dev \
+    openssl-dev \
+    pcre-dev \
+    libtirpc-dev \
+    flatbuffers-dev \ 
+    hyperscan-dev \
+    flex-dev
 
 ENV SRC_HOME=/snort_src
 WORKDIR ${SRC_HOME}
 
 ARG SAFEC_VER=02092020
 ADD https://github.com/rurban/safeclib/releases/download/v${SAFEC_VER}/libsafec-${SAFEC_VER}.tar.gz ${SRC_HOME}/libsafec-${SAFEC_VER}.tar
-RUN tar -xzvf libsafec-${SAFEC_VER}.tar && \
-  cd libsafec-${SAFEC_VER}.0-g6d921f && \
-  ./configure && \
-  make && \
-  make install
-
 ARG GPERF_VER=2.9.1
 ADD  https://github.com/gperftools/gperftools/releases/download/gperftools-${GPERF_VER}/gperftools-${GPERF_VER}.tar.gz ${SRC_HOME}/gperftools-${GPERF_VER}.tar
-RUN cd ${SRC_HOME} && \
+ARG DAQ_VER=3.0.2
+ADD https://github.com/snort3/libdaq/releases/download/v${DAQ_VER}/libdaq-${DAQ_VER}.tar.gz $SRC_HOME/libdaq-${DAQ_VER}.tar
+ARG SNORT_VER=3.1.3.0
+ADD https://github.com/snort3/snort3/archive/${SNORT_VER}.tar.gz ${SRC_HOME}/snort3-${SNORT_VER}.tar
+
+RUN echo "Build libsafec" && \
+  tar -xzvf libsafec-${SAFEC_VER}.tar && \
+  cd libsafec-${SAFEC_VER}.0-g6d921f && \
+  ./configure && \
+  make -j 4 && \
+  make install && \
+  echo "Build gperftools" && \
+  cd ${SRC_HOME} && \
   tar -xvf gperftools-$GPERF_VER.tar && \
   cd ${SRC_HOME}/gperftools-$GPERF_VER && \
   ./configure && \
-  make && \
-  make install
-
-ARG DAQ_VER=3.0.2
-ADD https://github.com/snort3/libdaq/releases/download/v${DAQ_VER}/libdaq-${DAQ_VER}.tar.gz $SRC_HOME/libdaq-${DAQ_VER}.tar
-RUN cd ${SRC_HOME} && \
+  make -j 4 && \
+  make install && \
+  echo "Build libdaq" && \
+  cd ${SRC_HOME} && \
   tar xvf libdaq-${DAQ_VER}.tar && \
   cd ${SRC_HOME}/libdaq-${DAQ_VER} && \
   ./configure && \
-  make && \
-  make install
-
-ARG SNORT_VER=3.1.3.0
-ADD https://github.com/snort3/snort3/archive/${SNORT_VER}.tar.gz ${SRC_HOME}/snort3-${SNORT_VER}.tar
-RUN cd ${SRC_HOME} && \
+  make -j 4 && \
+  make install && \
+  echo "Build Snort3" && \
+  cd ${SRC_HOME} && \
   tar xvf snort3-${SNORT_VER}.tar && \
   cd ${SRC_HOME}/snort3-${SNORT_VER} && \
   ./configure_cmake.sh --prefix=/usr/local --enable-tcmalloc && \
   cd build && \
-  make && \
-  make install
-
+  make -j 4 && \
+  make install && \
+  # Cleanup compilation
+  cd / && \
+  rm -rf ${SRC_HOME} && \
+  apk del \ 
+    build-base \ 
+    cmake 
 # Install all of our pip packages in a single directory that we can copy to our base image later
 RUN mkdir /install && \
   mkdir /rules
@@ -58,7 +84,7 @@ RUN addgroup snort3 && \
   adduser -h /app -G snort3 -D snort3
 COPY src /app
 RUN chown -R snort3:snort3 /app && \
-  chmod 755 /app/app.py
+  chmod 755 /app/app.py 
 USER snort3
 WORKDIR /app
 


### PR DESCRIPTION
Optimize Snort image size and faster image creation by compiling source code with parallelization (4 concurrent jobs).
The image size shrunk from 1.45GB to 630MB.

![Screen Shot 2021-09-06 at 11 46 43](https://user-images.githubusercontent.com/10239907/132244177-1b744025-9707-422a-a529-526e8677a3f1.png)
![Screen Shot 2021-09-06 at 23 08 10](https://user-images.githubusercontent.com/10239907/132244181-4306226e-9787-4bdc-a8b2-07275548a37c.png)
